### PR TITLE
Nguơn, TW, Đắk Lắk and quởn.

### DIFF
--- a/dictionaries/vi-DauCu.dic
+++ b/dictionaries/vi-DauCu.dic
@@ -1,4 +1,4 @@
-6631
+6638
 ABC
 ASCII
 GIF
@@ -9,6 +9,7 @@ Huế
 HĐND
 JPEG
 LHQ
+Nguơn
 Nguyễn
 Nẵng
 PDF
@@ -17,6 +18,7 @@ Phan
 RAM
 TCVN
 TV
+TW
 Telex
 Tp
 UBND

--- a/dictionaries/vi-DauCu.dic
+++ b/dictionaries/vi-DauCu.dic
@@ -1,4 +1,4 @@
-6640
+6641
 ABC
 ASCII
 GIF
@@ -4083,6 +4083,7 @@ quốc
 quớ
 quờ
 quở
+quởn
 quỳ
 quỳnh
 quỵ

--- a/dictionaries/vi-DauCu.dic
+++ b/dictionaries/vi-DauCu.dic
@@ -1,4 +1,4 @@
-6638
+6640
 ABC
 ASCII
 GIF
@@ -9,6 +9,7 @@ Huế
 HĐND
 JPEG
 LHQ
+Lắk
 Nguơn
 Nguyễn
 Nẵng
@@ -28,6 +29,7 @@ VIQR
 VISCII
 VN
 VNI
+Đắk
 a
 ai
 am

--- a/dictionaries/vi-DauMoi.dic
+++ b/dictionaries/vi-DauMoi.dic
@@ -1,4 +1,4 @@
-6631
+6638
 ABC
 ASCII
 GIF
@@ -9,6 +9,7 @@ Huế
 HĐND
 JPEG
 LHQ
+Nguơn
 Nguyễn
 Nẵng
 PDF
@@ -17,6 +18,7 @@ Phan
 RAM
 TCVN
 TV
+TW
 Telex
 Tp
 UBND

--- a/dictionaries/vi-DauMoi.dic
+++ b/dictionaries/vi-DauMoi.dic
@@ -1,4 +1,4 @@
-6638
+6640
 ABC
 ASCII
 GIF
@@ -9,6 +9,7 @@ Huế
 HĐND
 JPEG
 LHQ
+Lắk
 Nguơn
 Nguyễn
 Nẵng
@@ -28,6 +29,7 @@ VIQR
 VISCII
 VN
 VNI
+Đắk
 a
 ai
 am

--- a/dictionaries/vi-DauMoi.dic
+++ b/dictionaries/vi-DauMoi.dic
@@ -1,4 +1,4 @@
-6640
+6641
 ABC
 ASCII
 GIF
@@ -4087,6 +4087,7 @@ quốc
 quớ
 quờ
 quở
+quởn
 quỳ
 quỳnh
 quỵ


### PR DESCRIPTION
- Nguơn is a Southerner's sound for Nguyên(元), to avoid the name of
  Nguyễn Phúc Nguyên, the lord of Buddha. It's still in use today as
  the name of Vĩnh Nguơn ward, Châu Đốc city, An Giang province.
  Hoà Hảo's books also use Nguơn instead of Nguyên.

  Nguơn là âm miền Nam của Nguyên(元) tránh kỵ húy Chúa Sãi Nguyễn Phúc
  Nguyên. Từ này ngày nay vẫn được sử dụng trong tên chính thức của
  phường Vĩnh Nguơn, thành phố Châu Đốc, tỉnh An Giang. Kinh sách của
  Phật giáo Hòa Hảo cũng sử dụng "nguơn" thay vì "nguyên".

- TW is abbr. of "Trung ương".
  TW là tên viết tắt của "Trung ương", được sử dụng rất rộng rãi.

- Đắk Lắk as a province of Viet Nam.  Đắk Lắk là một tỉnh của Việt Nam.
- quởn is a common word in the south.